### PR TITLE
add option page

### DIFF
--- a/app/coffee/app.coffee
+++ b/app/coffee/app.coffee
@@ -196,4 +196,13 @@ do ->
   window.app = new App($('app'))
   do app.renderMonthLoop
 
+
+  # get state from local storage
+  chrome.storage.local.get 'showMonth',  (items) ->
+    if !items.showMonth
+      $('month-section').classList.add('hidden')
+    else
+      $('month-section').classList.remove('hidden')
+
+
   return

--- a/app/coffee/option.coffee
+++ b/app/coffee/option.coffee
@@ -1,0 +1,10 @@
+do ->
+  month = document.getElementById 'month-checkbox'
+
+  chrome.storage.local.get 'showMonth', (items) ->
+    month.checked = !!items.showMonth
+
+  month.onchange = (event) ->
+    chrome.storage.local.set { showMonth: event.target.checked } , () ->
+      console.log('saved')
+  

--- a/app/jade/dashboard.jade
+++ b/app/jade/dashboard.jade
@@ -25,12 +25,13 @@ html
     #chart(style='width:59%')
       svg(style='height:80px')
 
-    #month-bar
-    script#month-template(type='text/x-handlebars-template').
-      <h1 class="age-label">{{title}}</h1>
-      <h2 class="count">{{days}}<sup>.{{milliseconds}}</sup></h2>
-    #month-chart(style='width:59%')
-      svg(style='height:80px')
+    section#month-section
+      #month-bar
+      script#month-template(type='text/x-handlebars-template').
+        <h1 class="age-label">{{title}}</h1>
+        <h2 class="count">{{days}}<sup>.{{milliseconds}}</sup></h2>
+      #month-chart
+        svg(style='height:80px')
 
     script(src='js/libs/d3.v3.min.js')
     script(src='js/libs/nv.d3.min.js')

--- a/app/jade/option.jade
+++ b/app/jade/option.jade
@@ -1,0 +1,16 @@
+doctype html
+html
+  head
+    meta(charset='utf-8')
+    meta(http-equiv='X-UA-Compatible', content='IE=edge,chrome=1')
+    title Option
+    meta(name='description', content='')
+    meta(name='viewport', content='width=device-width')
+  
+    link(rel='stylesheet', href='css/vendor/nv.d3.css')
+  body
+    div
+      input#month-checkbox(type='checkbox')
+      label Display Monthly Countdown
+      
+    script(src='js/option.js')

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,6 +1,5 @@
 {
-"update_url": "https://clients2.google.com/service/update2/crx",
-
+   "update_url": "https://clients2.google.com/service/update2/crx",
    "background": {
       "persistent": false,
       "scripts": [ "js/background.js" ]
@@ -8,6 +7,10 @@
    "chrome_url_overrides": {
       "newtab": "dashboard.html"
    },
+   "permissions": [
+      "storage"
+   ],
+   "options_page": "option.html",
    "content_security_policy": "script-src 'self' 'unsafe-eval' https://www.google-analytics.com;  object-src 'self'",
    "description": "Replace new tab page with Life Is Too Short.",
    "manifest_version": 2,

--- a/app/sass/style.sass
+++ b/app/sass/style.sass
@@ -93,3 +93,6 @@ footer
   display: -webkit-flex
   -webkit-flex-direction: row
   -webkit-justify-content: center
+
+.hidden
+  display: none


### PR DESCRIPTION
This is not a complete solution to fix #15 . However this should give a rough idea of how to create option page for users to configure in chrome extension.

Be aware that the month-bar is shortened (obviously). I tried to fix it, but I found that it would be better to rewrite part of app.coffee and restructure of app.jade. And I really do not familiar with the dev stack coffee + jade + d3.. and I do not want to rewrite a lot without original authors' permission. I can contribute more if you switch to stack javascript + html/react.js and I have in-depth experience with chrome extension.

BTW, I really ❤ this app.
